### PR TITLE
Unique Function Names

### DIFF
--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -1,0 +1,3 @@
+pub const c = @cImport({
+    @cInclude("clang-c/Index.h");
+});


### PR DESCRIPTION
Removes default `ZPP_` prefix in lieu of signature hash suffix.